### PR TITLE
Fix wagon length unit

### DIFF
--- a/src/TrainComposition.svelte
+++ b/src/TrainComposition.svelte
@@ -65,7 +65,7 @@
                         <td>{wago.location}</td>
                         <td>{wago.salesNumber}</td>
                         <td>{wago.wagonType}</td>
-                        <td>{wago.length} mm</td>
+                        <td>{wago.length} cm</td>
                         <td>{#each ['playground', 'pet', 'catering','video','luggage','smoking','disabled'] as service}{#if wago[service]}{service}
                             &nbsp;{/if}{/each}</td>
                         <td>{wago.vehicleNumber || ""}</td>


### PR DESCRIPTION
![kuvakaappaus](https://github.com/user-attachments/assets/0b9c4c03-0e47-43bf-a2c5-48bbf601a0da)

Wagon lengths should be in centimetres, not millimetres.